### PR TITLE
Replace error catching from signature to try/catch

### DIFF
--- a/src/main/java/com/github/codeidoscope/HttpServerRunner.java
+++ b/src/main/java/com/github/codeidoscope/HttpServerRunner.java
@@ -26,6 +26,7 @@ class HttpServerRunner implements ServerRunner {
         serverConnection.createServerSocket(portNumber);
         while (serverShouldContinueRunning) {
             serverConnection.listenForClientConnection();
+            try {
             String input = serverConnection.getInput();
             if (input != null) {
                 Request request = requestParser.parse(input);
@@ -36,6 +37,9 @@ class HttpServerRunner implements ServerRunner {
                 serverConnection.closeClientConnection();
             }
             serverConnection.closeClientConnection();
+            } catch (IOException e) {
+                ServerLogger.serverLogger.log(Level.WARNING, "Error: " + e);
+            }
         }
         serverConnection.closeConnection();
     }

--- a/src/main/java/com/github/codeidoscope/Server.java
+++ b/src/main/java/com/github/codeidoscope/Server.java
@@ -1,11 +1,17 @@
 package com.github.codeidoscope;
 
 import java.io.IOException;
+import java.util.logging.Level;
 
 public class Server {
 
     public static void main(String[] args) throws IOException {
         Configuration.getInstance().validateArgsAndSetParams(args);
-        new HttpServerRunner().startServer(Configuration.getInstance().getPortNumber());
+        try {
+            new HttpServerRunner().startServer(Configuration.getInstance().getPortNumber());
+        } catch (IOException e) {
+            System.out.println(e);
+            ServerLogger.serverLogger.log(Level.WARNING, "Error: " + e);
+        }
     }
 }


### PR DESCRIPTION
Add try/catch statements to replace signature error throwing.

This change of error behaviour was made so that the serving of large video files can be handled. The likely scenario is as follow:

1. Chrome requests video file
2. The server responds
3. Chrome reads the headers and sees that the file is large
4. Chrome _closes the connection_
(Without the try/catch statement, the server raises a broken pipe error and closes) 
5. Chrome will try and send a new request for a _smaller_ chunk of the video file

With this solution, Firefox and Chrome handle small and large files with no issues. When tested on Safari, the browser does not display video files at all, and just raises errors.
